### PR TITLE
Update /v1/job API docs

### DIFF
--- a/website/content/api-docs/jobs.mdx
+++ b/website/content/api-docs/jobs.mdx
@@ -290,6 +290,8 @@ The table below shows this endpoint's support for
 
 - `:job_id` `(string: <required>)` - Specifies the ID of the job (as specified in
   the job file during submission). This is specified as part of the path.
+- `namespace` `(string: "default")` - Specifies the target namespace. Specifying
+  `*` would return all jobs across all the authorized namespaces.
 
 ### Sample Request
 
@@ -298,11 +300,17 @@ $ curl \
     https://localhost:4646/v1/job/my-job
 ```
 
+```shell-session
+$ curl \
+    https://localhost:4646/v1/job/my-job?namespace=apps
+```
+
 ### Sample Response
 
 ```json
 {
   "Region": "global",
+  "Namespace": "apps",
   "ID": "example",
   "ParentID": "",
   "Name": "example",


### PR DESCRIPTION
The documentation for /v1/job endpoint is missing the `?namespace=` query parameter